### PR TITLE
feature/session_notworking #time 2h sessionManager Notworking 수정

### DIFF
--- a/src/main/java/io/security/corespringsecurity/security/SecurityUser.java
+++ b/src/main/java/io/security/corespringsecurity/security/SecurityUser.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@EqualsAndHashCode(of = "username")
 public class SecurityUser implements UserDetails {
 
     private String username;


### PR DESCRIPTION
spring security sessionManager
maximumsession
maxSessionsPreventsLogin
동작 하지 않는것 관련 수정
----------------------
SecurityUser 수정
UserDetails를 구현한 객체에서
@EqualsAndHashCode(of = "username") 추가하여 해결

EqualsAndHashCode를 추가하지 않으면
SessionRegistryImpl 클래스에서
getAllSessions 메소드의
final Set<String> sessionsUsedByPrincipal = principals.get(principal);

부분에서 get해올때 username이 아닌 객체 주소를 가지고 세션을 저장되어 있는 세션을 가지고 오려고 하기 때문에, 동시성 체크가 되지 않음