### PR TITLE
feature/session_manager_login_fail #time 2h 세션 동시성 설정 Enable시 로그아웃을 하…

### DIFF
--- a/src/main/java/io/security/corespringsecurity/security/configs/SecurityConfig.java
+++ b/src/main/java/io/security/corespringsecurity/security/configs/SecurityConfig.java
@@ -5,6 +5,7 @@ import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -12,9 +13,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.session.HttpSessionEventPublisher;
 
 @Configuration
 @EnableWebSecurity
@@ -64,6 +68,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .maximumSessions(1)
                 .expiredUrl("/")
                 .maxSessionsPreventsLogin(true)
+                .sessionRegistry(sessionRegistry())
                 ;
 //
 //        http
@@ -80,5 +85,17 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     public void configure(WebSecurity web) throws Exception {
         web.ignoring()
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    }
+
+    @Bean
+    public SessionRegistry sessionRegistry() {
+        SessionRegistry sessionRegistry = new SessionRegistryImpl();
+        return sessionRegistry;
+    }
+
+    // Register HttpSessionEventPublisher
+    @Bean
+    public static ServletListenerRegistrationBean httpSessionEventPublisher() {
+        return new ServletListenerRegistrationBean(new HttpSessionEventPublisher());
     }
 }


### PR DESCRIPTION
…였는데도 다른 브라우저에서 로그인 안되는 이슈 해결

logout시 SecurityContextHolder를 clear하지만 세션을 체크하는
ConcurrentSessionControlAuthenticationStrategy클래스
onAuthentication 메소드에서 sessionRegistry.getAllSessions 를 하게 되는데 이때 로그아웃 하였지만 아직 데이터가 남아 있기 때문에, 로그인이 불가능하게 된다.

 Logout 되더라도 sessionInformation 의 expried 속성은 여전히 false 상태임. LogoutFilter 에서 sessionInformation 의 expired 속성을 true 로 하면 될 것 같은데 구조상 LogoutFiler 에서 sessionInformation 의 정보를 참조하거나 관련된 메서드를 호출하는 것은 좋은 설계가 아니라는 판단이 듦 다만 어떠한 형태로든 로그아웃 시점에서 동시적 세션처리 관련 작업이 이루어져야 하는 것은 분명하므로  로그아웃 시 발생하는 이벤트 리스너를 사용하여 해결하고 있는 것으로 판단됨

 HttpSessionEventPublisher 를 사용하여 해결